### PR TITLE
chore: bump otterscale and dashboard image tags to v1.0.5 and v1.0.8 …

### DIFF
--- a/charts/otterscale/Chart.yaml
+++ b/charts/otterscale/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otterscale
-appVersion: SXHR0100-0001
-version: 1.0.1
+appVersion: SXHR0100-0002
+version: 1.0.2
 description: OtterScale - A unified platform for simplified compute, storage, and networking
 home: https://otterscale.github.io
 icon: https://github.com/otterscale.png

--- a/charts/otterscale/values.yaml
+++ b/charts/otterscale/values.yaml
@@ -64,7 +64,7 @@ server:
   image:
     repository: ghcr.io/otterscale/otterscale
     # renovate: image=ghcr.io/otterscale/otterscale
-    tag: "v1.0.2"
+    tag: "v1.0.5"
     pullPolicy: IfNotPresent
 
   # -- Container ports.
@@ -260,7 +260,7 @@ dashboard:
   image:
     repository: ghcr.io/otterscale/dashboard
     # renovate: image=ghcr.io/otterscale/dashboard
-    tag: "v1.0.6"
+    tag: "v1.0.8"
     pullPolicy: IfNotPresent
 
   # -- Container ports.


### PR DESCRIPTION
…respectively