### PR TITLE
feat: NFD detect GPU PCI ID

### DIFF
--- a/charts/otterscale-node-feature-discovery/files/gpu-features.sh
+++ b/charts/otterscale-node-feature-discovery/files/gpu-features.sh
@@ -1,0 +1,61 @@
+#!/bin/sh
+# Writes otterscale.io/gpu-* lines for NFD local source (POSIX sh — Alpine-friendly).
+# Scans PCI devices via host sysfs for NVIDIA GPUs (vendor 0x10de, class 0x03xx).
+# Outputs:
+#   otterscale.io/gpu-count=<total>
+#   otterscale.io/gpu-pci-<device_id>=<count>   (one line per unique PCI device ID)
+#
+# Requires SYS_ROOT to be set to host sysfs mount point (e.g. /host/sys).
+
+set -eu
+
+SYS_ROOT="${SYS_ROOT:-/sys}"
+PCI_DIR="${SYS_ROOT}/bus/pci/devices"
+
+if [ ! -d "${PCI_DIR}" ]; then
+  echo "otterscale.io/gpu-count=0"
+  exit 0
+fi
+
+# Collect all NVIDIA display-class device IDs into a temp file.
+# Class 0x03xxxx = Display controller (VGA-compatible, XGA, 3D, etc.)
+TMP_IDS=""
+total=0
+
+for dev in "${PCI_DIR}"/*/; do
+  vendor_file="${dev}vendor"
+  [ -r "${vendor_file}" ] || continue
+  vendor="$(cat "${vendor_file}" 2>/dev/null || true)"
+  [ "${vendor}" = "0x10de" ] || continue
+
+  class_file="${dev}class"
+  class="$(cat "${class_file}" 2>/dev/null || true)"
+  # Must be display class: 0x03xxxx
+  case "${class}" in
+    0x03*) ;;
+    *) continue ;;
+  esac
+
+  device_file="${dev}device"
+  [ -r "${device_file}" ] || continue
+  device="$(cat "${device_file}" 2>/dev/null || true)"
+  [ -n "${device}" ] || continue
+
+  # Normalize: strip leading "0x" and lowercase → e.g. "2684"
+  did="$(printf '%s' "${device#0x}" | tr 'A-F' 'a-f')"
+  [ -n "${did}" ] || continue
+
+  TMP_IDS="${TMP_IDS}${did}
+"
+  total=$((total + 1))
+done
+
+echo "otterscale.io/gpu-count=${total}"
+
+[ "${total}" -gt 0 ] || exit 0
+
+# Count per device ID and emit one label per unique ID.
+printf '%s' "${TMP_IDS}" | grep -v '^$' | sort | uniq -c | while read -r count did; do
+  [ -n "${did}" ] || continue
+  echo "otterscale.io/gpu-pci-${did}=${count}"
+done

--- a/charts/otterscale-node-feature-discovery/templates/configmap.yaml
+++ b/charts/otterscale-node-feature-discovery/templates/configmap.yaml
@@ -9,4 +9,6 @@ metadata:
 data:
   disk-features.sh: |
 {{ .Files.Get "files/disk-features.sh" | nindent 4 }}
+  gpu-features.sh: |
+{{ .Files.Get "files/gpu-features.sh" | nindent 4 }}
 {{- end }}

--- a/charts/otterscale-node-feature-discovery/templates/daemonset.yaml
+++ b/charts/otterscale-node-feature-discovery/templates/daemonset.yaml
@@ -67,15 +67,22 @@ spec:
             - |
               set -eu
               OUT_DIR="/etc/kubernetes/node-feature-discovery/features.d"
-              TMP="${OUT_DIR}/.{{ .Values.featureWriter.featureFileName }}.tmp"
-              FINAL="${OUT_DIR}/{{ .Values.featureWriter.featureFileName }}"
+              DISK_TMP="${OUT_DIR}/.{{ .Values.featureWriter.featureFileName }}.tmp"
+              DISK_FINAL="${OUT_DIR}/{{ .Values.featureWriter.featureFileName }}"
+              GPU_TMP="${OUT_DIR}/.{{ .Values.featureWriter.gpuFeatureFileName }}.tmp"
+              GPU_FINAL="${OUT_DIR}/{{ .Values.featureWriter.gpuFeatureFileName }}"
               INTERVAL={{ .Values.featureWriter.intervalSeconds | int }}
               mkdir -p "${OUT_DIR}"
               while true; do
-                if /bin/sh /scripts/disk-features.sh > "${TMP}"; then
-                  mv -f "${TMP}" "${FINAL}"
+                if /bin/sh /scripts/disk-features.sh > "${DISK_TMP}"; then
+                  mv -f "${DISK_TMP}" "${DISK_FINAL}"
                 else
-                  rm -f "${TMP}"
+                  rm -f "${DISK_TMP}"
+                fi
+                if /bin/sh /scripts/gpu-features.sh > "${GPU_TMP}"; then
+                  mv -f "${GPU_TMP}" "${GPU_FINAL}"
+                else
+                  rm -f "${GPU_TMP}"
                 fi
                 sleep "${INTERVAL}"
               done

--- a/charts/otterscale-node-feature-discovery/values.yaml
+++ b/charts/otterscale-node-feature-discovery/values.yaml
@@ -21,6 +21,7 @@ featureWriter:
   imagePullPolicy: IfNotPresent
   intervalSeconds: 60
   featureFileName: otterscale-disk-features
+  gpuFeatureFileName: otterscale-gpu-features
   # Script only publishes "data disk" candidates: excludes loop, ram, zram, dm-*, fd*, and nbd* by default.
   dataDiskIncludeNbd: false
   resources:


### PR DESCRIPTION
## Summary

Add GPU PCI ID detection to `otterscale-node-feature-discovery` chart via a new NFD local-source script.

- **New script** `gpu-features.sh`: scans host sysfs (`/sys/bus/pci/devices`) for NVIDIA GPUs (vendor `0x10de`, PCI class `0x03xxxx`) and emits NFD labels:
  - `otterscale.io/gpu-count=<total>` — total number of detected GPUs on the node
  - `otterscale.io/gpu-pci-<device_id>=<count>` — count per unique PCI device ID
- **ConfigMap**: mounts `gpu-features.sh` alongside the existing `disk-features.sh`
- **DaemonSet**: runs `gpu-features.sh` in the same polling loop as disk detection; writes output to a separate feature file (`otterscale-gpu-features`)
- **values.yaml**: adds `gpuFeatureFileName` field (`otterscale-gpu-features`)

## Test Plan

- [ ] Deploy on a node with NVIDIA GPU(s); verify `otterscale.io/gpu-count` and `otterscale.io/gpu-pci-*` labels appear on the node
- [ ] Deploy on a node without any GPU; verify only `otterscale.io/gpu-count=0` is emitted and no crash occurs