### PR TITLE
feat(charts): bump version to 1.2.0 for multiple charts

### DIFF
--- a/charts/otterscale-containerized-data-importer-base/Chart.yaml
+++ b/charts/otterscale-containerized-data-importer-base/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: otterscale-containerized-data-importer-base
-version: 1.1.0
+version: 1.2.0
 # renovate: github=kubevirt/containerized-data-importer
 appVersion: "1.65.0"
 description: >-

--- a/charts/otterscale-containerized-data-importer/Chart.yaml
+++ b/charts/otterscale-containerized-data-importer/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: otterscale-containerized-data-importer
-version: 1.1.0
+version: 1.2.0
 # renovate: github=kubevirt/containerized-data-importer
 appVersion: "1.65.0"
 description: >-

--- a/charts/otterscale-envoy-ai-gateway-base/Chart.yaml
+++ b/charts/otterscale-envoy-ai-gateway-base/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: otterscale-envoy-ai-gateway-base
-version: 1.1.0
+version: 1.2.0
 # renovate: helm=ai-gateway-crds-helm registry=oci://docker.io/envoyproxy
 appVersion: "0.5.0"
 description: >-

--- a/charts/otterscale-envoy-ai-gateway/Chart.yaml
+++ b/charts/otterscale-envoy-ai-gateway/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: otterscale-envoy-ai-gateway
-version: 1.1.3
+version: 1.2.0
 # renovate: helm=ai-gateway-helm registry=oci://docker.io/envoyproxy
 appVersion: "0.5.0"
 description: >-

--- a/charts/otterscale-envoy-gateway/Chart.lock
+++ b/charts/otterscale-envoy-gateway/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: gateway-helm
   repository: oci://docker.io/envoyproxy
-  version: 1.7.2
-digest: sha256:bfc61865dd198b2093911e1e1b8a9f6ecb817cfc2d293bc09a858268b256f030
-generated: "2026-04-29T14:14:08.613800281+08:00"
+  version: 1.7.3
+digest: sha256:e283ee82713cd8cde0fbd5fa3a01c3cba2364a69a9532f47b6f542413b7048e6
+generated: "2026-06-01T19:42:49.614200381+08:00"

--- a/charts/otterscale-envoy-gateway/Chart.yaml
+++ b/charts/otterscale-envoy-gateway/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: otterscale-envoy-gateway
-version: 1.1.2
+version: 1.2.0
 # renovate: helm=gateway-helm registry=oci://docker.io/envoyproxy
-appVersion: "1.7.2"
+appVersion: "1.7.3"
 description: >-
   Envoy Gateway — Kubernetes-native Gateway API implementation
   powered by Envoy Proxy.
@@ -24,5 +24,5 @@ annotations:
   artifacthub.io/license: Apache-2.0
 dependencies:
   - name: gateway-helm
-    version: 1.7.2
+    version: 1.7.3
     repository: oci://docker.io/envoyproxy

--- a/charts/otterscale-envoy-gateway/templates/rbac.yaml
+++ b/charts/otterscale-envoy-gateway/templates/rbac.yaml
@@ -1,0 +1,89 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+  name: otterscale-httproute-admin
+rules:
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - httproutes
+    verbs:
+      - "*"
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - httproutes/status
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+  name: otterscale-httproute-editor
+rules:
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - httproutes
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - httproutes/status
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  name: otterscale-httproute-viewer
+rules:
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - httproutes
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - httproutes/status
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  name: otterscale-gateway-viewer
+rules:
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - gateways
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - gateways/status
+    verbs:
+      - get

--- a/charts/otterscale-gpu-operator/Chart.lock
+++ b/charts/otterscale-gpu-operator/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: gpu-operator
   repository: https://nvidia.github.io/gpu-operator
-  version: v26.3.1
-digest: sha256:e69ceb2ae46cfe90c3db89b326dc6b2b99acb0cf17dd4a449f99c4dcb0d4f0a9
-generated: "2026-04-30T10:08:28.589062342+08:00"
+  version: v26.3.2
+digest: sha256:ac6417d19bbbec7b9b3db12d3de6e487b84a2d9470061dfcb76d8d8cd2f2fd8a
+generated: "2026-06-01T19:22:18.786608399+08:00"

--- a/charts/otterscale-gpu-operator/Chart.yaml
+++ b/charts/otterscale-gpu-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: otterscale-gpu-operator
-version: 1.1.0
+version: 1.2.0
 # renovate: helm=gpu-operator registry=https://nvidia.github.io/gpu-operator
-appVersion: "26.3.1"
+appVersion: "v26.3.2"
 description: >-
   NVIDIA GPU Operator — drivers, DCGM, DCGM Exporter, Node Status Exporter.
   Device plugin disabled for use with HAMI vGPU.
@@ -25,5 +25,5 @@ annotations:
   artifacthub.io/license: Apache-2.0
 dependencies:
   - name: gpu-operator
-    version: 26.3.1
+    version: v26.3.2
     repository: https://nvidia.github.io/gpu-operator

--- a/charts/otterscale-hami/Chart.lock
+++ b/charts/otterscale-hami/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: hami
   repository: https://project-hami.github.io/HAMi/
-  version: 2.8.0
-digest: sha256:42360da1a70a33f30e8765c0a40736bbb9b2a53dcc375de126c33ef61b47d04f
-generated: "2026-04-24T17:08:46.447112439+08:00"
+  version: 2.9.0
+digest: sha256:803f1e9e61b4081b74c6cc6f6ad60291fc5f86e1ad0f5df994ac554a72310c03
+generated: "2026-06-01T19:23:28.346798426+08:00"

--- a/charts/otterscale-hami/Chart.yaml
+++ b/charts/otterscale-hami/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: otterscale-hami
-version: 1.1.0
+version: 1.2.0
 # renovate: helm=hami registry=https://project-hami.github.io/HAMi/
-appVersion: "2.8.0"
+appVersion: "2.9.0"
 description: >-
   HAMI — GPU sharing (vGPU) with device split, memory/core scaling.
   Integrates with NVIDIA GPU Operator.
@@ -26,5 +26,5 @@ annotations:
   artifacthub.io/license: Apache-2.0
 dependencies:
   - name: hami
-    version: 2.8.0
+    version: 2.9.0
     repository: https://project-hami.github.io/HAMi/

--- a/charts/otterscale-kserve-base/Chart.yaml
+++ b/charts/otterscale-kserve-base/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: otterscale-kserve-base
-version: 1.1.2
+version: 1.2.0
 # renovate: helm=kserve registry=oci://ghcr.io/kserve/charts
 appVersion: "v0.18.0"
 description: >-

--- a/charts/otterscale-kserve-crd/Chart.yaml
+++ b/charts/otterscale-kserve-crd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: otterscale-kserve-crd
-version: 1.1.2
+version: 1.2.0
 # renovate: helm=kserve registry=oci://ghcr.io/kserve/charts
 appVersion: "v0.18.0"
 description: >-

--- a/charts/otterscale-kserve-resource/Chart.yaml
+++ b/charts/otterscale-kserve-resource/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: otterscale-kserve-resource
-version: 1.1.8
+version: 1.2.0
 # renovate: helm=kserve registry=oci://ghcr.io/kserve/charts
 appVersion: "v0.18.0"
 description: >-

--- a/charts/otterscale-kserve-runtime-configs/Chart.yaml
+++ b/charts/otterscale-kserve-runtime-configs/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: otterscale-kserve-runtime-configs
-version: 1.1.0
+version: 1.2.0
 # renovate: helm=kserve registry=oci://ghcr.io/kserve/charts
 appVersion: "v0.18.0"
 description: >-

--- a/charts/otterscale-kube-resource-orchestrator/Chart.lock
+++ b/charts/otterscale-kube-resource-orchestrator/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: kro
   repository: oci://registry.k8s.io/kro/charts
-  version: 0.9.1
-digest: sha256:7f1261e247ea33037401baeefa78d33060ffdc0eface816ace46ca4a5b9fa451
-generated: "2026-04-15T10:47:08.222843229Z"
+  version: 0.9.2
+digest: sha256:dfdc1321fe7f6ff8924d98350fba22c9354b76e5c4796c3fe88786a774baceb0
+generated: "2026-06-01T19:23:55.736664743+08:00"

--- a/charts/otterscale-kube-resource-orchestrator/Chart.yaml
+++ b/charts/otterscale-kube-resource-orchestrator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: otterscale-kube-resource-orchestrator
-version: 1.1.2
+version: 1.2.0
 # renovate: helm=kro registry=oci://registry.k8s.io/kro/charts
-appVersion: "v0.9.1"
+appVersion: "v0.9.2"
 description: >-
   kro (Kube Resource Orchestrator) — define reusable Kubernetes
   abstractions with ResourceGraphDefinitions and CEL expressions.
@@ -24,5 +24,5 @@ annotations:
   artifacthub.io/license: Apache-2.0
 dependencies:
   - name: kro
-    version: 0.9.1
+    version: 0.9.2
     repository: oci://registry.k8s.io/kro/charts

--- a/charts/otterscale-kubevirt-base/Chart.yaml
+++ b/charts/otterscale-kubevirt-base/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: otterscale-kubevirt-base
-version: 1.1.0
+version: 1.2.0
 # renovate: github=kubevirt/kubevirt
 appVersion: "1.8.2"
 description: >-

--- a/charts/otterscale-kubevirt/Chart.yaml
+++ b/charts/otterscale-kubevirt/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: otterscale-kubevirt
-version: 1.1.0
+version: 1.2.0
 # renovate: github=kubevirt/kubevirt
 appVersion: "1.8.2"
 description: >-

--- a/charts/otterscale-leader-worker-set/Chart.yaml
+++ b/charts/otterscale-leader-worker-set/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: otterscale-leader-worker-set
-version: 1.1.0
+version: 1.2.0
 # renovate: github=kubernetes-sigs/lws
 appVersion: "0.8.0"
 description: >-

--- a/charts/otterscale-prometheus/Chart.lock
+++ b/charts/otterscale-prometheus/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: kube-prometheus-stack
   repository: https://prometheus-community.github.io/helm-charts
-  version: 84.3.0
-digest: sha256:c5da969a85a54304b4a0ef7e76d6c438fa93e35fb9fb137c18dcf47af8f4e8a0
-generated: "2026-04-30T10:01:53.071770212+08:00"
+  version: 86.1.0
+digest: sha256:f5d59d11846ac1fb25a887ec70b907affbeb53dfb01bfcbd57ffa2bd8984f0dd
+generated: "2026-06-01T19:24:12.12911852+08:00"

--- a/charts/otterscale-prometheus/Chart.yaml
+++ b/charts/otterscale-prometheus/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: otterscale-prometheus
-version: 1.1.0
+version: 1.2.0
 # renovate: helm=kube-prometheus-stack registry=https://prometheus-community.github.io/helm-charts
-appVersion: "84.3.0"
+appVersion: "86.1.0"
 description: >-
   kube-prometheus-stack — Prometheus, Alertmanager, Node Exporter.
   Grafana disabled; persistent storage with remote-write receiver.
@@ -24,5 +24,5 @@ annotations:
   artifacthub.io/license: Apache-2.0
 dependencies:
   - name: kube-prometheus-stack
-    version: 84.3.0
+    version: 86.1.0
     repository: https://prometheus-community.github.io/helm-charts

--- a/charts/otterscale-rook-ceph/Chart.yaml
+++ b/charts/otterscale-rook-ceph/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: otterscale-rook-ceph
-version: 1.1.0
+version: 1.2.0
 # renovate: helm=rook-ceph registry=https://charts.rook.io/release
 appVersion: "1.19.5"
 description: >-


### PR DESCRIPTION
Updated the version number to 1.2.0 in the following charts:
- otterscale-containerized-data-importer-base
- otterscale-containerized-data-importer
- otterscale-envoy-ai-gateway-base
- otterscale-envoy-ai-gateway
- otterscale-envoy-gateway
- otterscale-gpu-operator
- otterscale-hami
- otterscale-kserve-base
- otterscale-kserve-crd
- otterscale-kserve-resource
- otterscale-kserve-runtime-configs
- otterscale-kube-resource-orchestrator
- otterscale-kubevirt-base
- otterscale-kubevirt
- otterscale-leader-worker-set
- otterscale-prometheus
- otterscale-rook-ceph