### PR TITLE
feat: bump version to 1.2.0-rc.1 and update image tags

### DIFF
--- a/charts/otterscale/Chart.yaml
+++ b/charts/otterscale/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otterscale
-appVersion: SXHR0101-0004
-version: 1.1.4
+appVersion: SXHR0102T-0000
+version: 1.2.0-rc.1
 description: OtterScale - A unified platform for simplified compute, storage, and networking
 home: https://otterscale.github.io
 icon: https://github.com/otterscale.png

--- a/charts/otterscale/templates/_helpers.tpl
+++ b/charts/otterscale/templates/_helpers.tpl
@@ -289,3 +289,16 @@ Usage: {{ include "otterscale.image" (dict "imageRoot" .Values.server.image "glo
   {{- printf "%s:%s" $repository $tag -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Render the dashboard image reference.
+When ee.enabled is true, the repository is switched to its "-ee" variant
+(e.g. ghcr.io/otterscale/dashboard → ghcr.io/otterscale/dashboard-ee).
+*/}}
+{{- define "otterscale.dashboard.image" -}}
+{{- $imageRoot := .Values.dashboard.image -}}
+{{- if .Values.ee.enabled -}}
+  {{- $imageRoot = merge (dict "repository" (printf "%s-ee" .Values.dashboard.image.repository)) (omit .Values.dashboard.image "repository") -}}
+{{- end -}}
+{{- include "otterscale.image" (dict "imageRoot" $imageRoot "global" .Values.global "chart" .Chart) -}}
+{{- end -}}

--- a/charts/otterscale/templates/_helpers.tpl
+++ b/charts/otterscale/templates/_helpers.tpl
@@ -296,9 +296,9 @@ When ee.enabled is true, the repository is switched to its "-ee" variant
 (e.g. ghcr.io/otterscale/dashboard → ghcr.io/otterscale/dashboard-ee).
 */}}
 {{- define "otterscale.dashboard.image" -}}
-{{- $imageRoot := .Values.dashboard.image -}}
+{{- $imageRoot := deepCopy .Values.dashboard.image -}}
 {{- if .Values.ee.enabled -}}
-  {{- $imageRoot = merge (dict "repository" (printf "%s-ee" .Values.dashboard.image.repository)) (omit .Values.dashboard.image "repository") -}}
+  {{- $_ := set $imageRoot "repository" (printf "%s-ee" $imageRoot.repository) -}}
 {{- end -}}
 {{- include "otterscale.image" (dict "imageRoot" $imageRoot "global" .Values.global "chart" .Chart) -}}
 {{- end -}}

--- a/charts/otterscale/templates/dashboard/deployment.yaml
+++ b/charts/otterscale/templates/dashboard/deployment.yaml
@@ -49,7 +49,7 @@ spec:
       {{- end }}
       containers:
         - name: otterscale-dashboard
-          image: {{ include "otterscale.image" (dict "imageRoot" .Values.dashboard.image "global" .Values.global "chart" .Chart) | quote }}
+          image: {{ include "otterscale.dashboard.image" . | quote }}
           imagePullPolicy: {{ .Values.dashboard.image.pullPolicy }}
           {{- with .Values.dashboard.containerSecurityContext }}
           securityContext:

--- a/charts/otterscale/values.yaml
+++ b/charts/otterscale/values.yaml
@@ -21,6 +21,14 @@ nameOverride: ""
 fullnameOverride: ""
 
 # =============================================================================
+# Enterprise Edition (EE) Configuration
+# =============================================================================
+ee:
+  # -- Enable Enterprise Edition. When true, the dashboard image repository
+  # is switched to its "-ee" variant (e.g. ghcr.io/otterscale/dashboard-ee).
+  enabled: false
+
+# =============================================================================
 # Storage Configuration
 # =============================================================================
 storage:
@@ -64,7 +72,7 @@ server:
   image:
     repository: ghcr.io/otterscale/otterscale
     # renovate: image=ghcr.io/otterscale/otterscale
-    tag: "v1.1.2"
+    tag: "v1.2.0-rc.2"
     pullPolicy: IfNotPresent
 
   # -- Container ports.
@@ -260,7 +268,7 @@ dashboard:
   image:
     repository: ghcr.io/otterscale/dashboard
     # renovate: image=ghcr.io/otterscale/dashboard
-    tag: "v1.1.18"
+    tag: "v1.2.0-beta.1"
     pullPolicy: IfNotPresent
 
   # -- Container ports.


### PR DESCRIPTION
- Chart version 1.1.4 -> 1.2.0-rc.1, appVersion -> SXHR0102T-0000
- server image tag -> v1.2.0-rc.2, dashboard image tag -> v1.2.0-beta.1
- add ee.enabled flag and otterscale.dashboard.image helper to switch dashboard repository to its -ee variant when EE is enabled