### PR TITLE
feat(charts): update version for otterscale-envoy-gateway and rook-ce…

### DIFF
--- a/charts/otterscale-envoy-gateway/Chart.yaml
+++ b/charts/otterscale-envoy-gateway/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: otterscale-envoy-gateway
-version: 1.2.0
+version: 1.2.1
 # renovate: helm=gateway-helm registry=oci://docker.io/envoyproxy
 appVersion: "1.7.3"
 description: >-

--- a/charts/otterscale-envoy-gateway/templates/rbac.yaml
+++ b/charts/otterscale-envoy-gateway/templates/rbac.yaml
@@ -70,7 +70,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
   name: otterscale-gateway-viewer
 rules:
   - apiGroups:

--- a/charts/otterscale-rook-ceph-cluster/Chart.yaml
+++ b/charts/otterscale-rook-ceph-cluster/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: otterscale-rook-ceph-cluster
-version: 1.1.2
+version: 1.2.0
 # renovate: helm=rook-ceph-cluster registry=https://charts.rook.io/release
 appVersion: "1.19.5"
 description: >-


### PR DESCRIPTION
…ph-cluster

- Bump version of otterscale-envoy-gateway to 1.2.1
- Bump version of otterscale-rook-ceph-cluster to 1.2.0
- Add aggregate-to-edit label for otterscale-gateway-viewer role