### PR TITLE
feat(chart): upgrade version to 1.2.1 and appVersion to 1.1.0

### DIFF
--- a/charts/otterscale-lincense-operator/Chart.yaml
+++ b/charts/otterscale-lincense-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otterscale-lincense-operator
-version: 1.2.0
-appVersion: "1.0.0"
+version: 1.2.1
+appVersion: "1.1.0"
 description: >-
   Otterscale lincense operator chart.
 home: https://otterscale.github.io

--- a/charts/otterscale-lincense-operator/templates/install.yaml
+++ b/charts/otterscale-lincense-operator/templates/install.yaml
@@ -1,4 +1,3 @@
-# Add resources for otterscale-lincense-operator here.
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -565,7 +564,7 @@ spec:
         - --health-probe-bind-address=:8081
         command:
         - /manager
-        image: ghcr.io/otterscale/license-operator:v1.0.0
+        image: ghcr.io/otterscale/license-operator:v1.1.0
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
Updated the Chart.yaml to reflect the new version 1.2.1 and appVersion 1.1.0 for the otterscale-lincense-operator. Also updated the image version in install.yaml to v1.1.0.