### PR TITLE
fix(otterscale-kserve-resource): scrape llmisvc metrics on http port

### DIFF
--- a/charts/otterscale-kserve-resource/Chart.yaml
+++ b/charts/otterscale-kserve-resource/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: otterscale-kserve-resource
-version: 1.4.0-rc.6
+version: 1.4.0-rc.7
 # renovate: helm=kserve registry=oci://ghcr.io/kserve/charts
 appVersion: "v0.20.0-rc0.1"
 description: >-

--- a/charts/otterscale-kserve-resource/templates/servicemonitor.yaml
+++ b/charts/otterscale-kserve-resource/templates/servicemonitor.yaml
@@ -17,6 +17,17 @@ spec:
       - __meta_kubernetes_service_label_app_kubernetes_io_name
       targetLabel: llm_inference_service
     scrapeTimeout: 15s
+  - honorLabels: false
+    honorTimestamps: false
+    interval: 15s
+    path: /metrics
+    port: http
+    relabelings:
+    - action: replace
+      sourceLabels:
+      - __meta_kubernetes_service_label_app_kubernetes_io_name
+      targetLabel: llm_inference_service
+    scrapeTimeout: 15s
   namespaceSelector:
     any: true
   selector:


### PR DESCRIPTION
The kserve-llmisvc ServiceMonitor only scraped the https port, so LLMInferenceService workloads exposing /metrics over plain http were not collected. Add a second endpoint targeting the http port with the same interval, path and llm_inference_service relabeling.

Bump chart version to 1.4.0-rc.7.