### PR TITLE
[SYSTOOL021-4749] feat: add clusterrole to read Rancher Resource

### DIFF
--- a/charts/otterscale/templates/server/clusterrole.yaml
+++ b/charts/otterscale/templates/server/clusterrole.yaml
@@ -1,0 +1,10 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "otterscale.server.fullname" . }}
+  labels:
+    {{- include "otterscale.server.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["management.cattle.io"]
+    resources: ["projects"]
+    verbs: ["get", "list", "watch"]

--- a/charts/otterscale/templates/server/clusterrolebinding.yaml
+++ b/charts/otterscale/templates/server/clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "otterscale.server.fullname" . }}
+  labels:
+    {{- include "otterscale.server.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "otterscale.server.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "otterscale.server.serviceAccountName" . }}
+    namespace: {{ include "otterscale.namespace" . }}


### PR DESCRIPTION
- Add a server `ClusterRole` granting only `get/list/watch` access to Rancher Projects, and bind it to the existing OtterScale server `ServiceAccount`.
- Support both chart-created and existing ServiceAccounts without adding Rancher credentials or configuration.